### PR TITLE
GitHub Actions の paths_ignore を使う

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
     - master
+    paths-ignore:
+    - "docs/**"
 
 jobs:
   build:


### PR DESCRIPTION
CI で docs にデプロイした後にもう一度 CI が無駄に回っていたが、以下のアップデートにより改修できそう
https://github.blog/changelog/2019-09-30-github-actions-event-filtering-updates/