### PR TITLE
NEWS ページの Prev/Next ボタンのリンクを修正

### DIFF
--- a/config-prod.toml
+++ b/config-prod.toml
@@ -1,6 +1,7 @@
 languageCode = "en-ja"
 title = "群馬大学電子計算機研究会 IGGG"
 baseURL = "https://iggg.github.io/new.iggg.org/"
+canonifyURLs = true
 theme = "dopetrope"
 publishdir = "docs"
 

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,7 @@
 languageCode = "en-ja"
 title = "群馬大学電子計算機研究会 IGGG"
 baseURL = "http://localhost:1313/"
+canonifyURLs = true
 theme = "dopetrope"
 
 [params]


### PR DESCRIPTION
baseUrl がホスト以外も含むのため canonifyURLs を true にする必要があった
https://gohugo.io/getting-started/configuration/